### PR TITLE
Remove `DiffEqBase` from the dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -14,7 +13,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ArrayInterface = "3"
-DiffEqBase = "6"
 DocStringExtensions = "0.8"
 RecursiveArrayTools = "2"
 SciMLBase = "1"


### PR DESCRIPTION
`DiffEqBase` isn't actually used and it causes a circular dependency in https://github.com/SciML/DiffEqBase.jl/pull/690